### PR TITLE
Update GetOrderByIdAsync to return nullable Order

### DIFF
--- a/src/fiap-order-service/Repositories/IOrderRepository.cs
+++ b/src/fiap-order-service/Repositories/IOrderRepository.cs
@@ -5,7 +5,7 @@ namespace fiap_order_service.Repositories
     public interface IOrderRepository
     {
         Task<List<Order>> GetAllOrdersAsync();
-        Task<Order> GetOrderByIdAsync(Guid id);
+        Task<Order?> GetOrderByIdAsync(Guid id);
         Task<Order?> CreateOrderAsync(Order order);
         Task<Order?> UpdateStatusOrderAsync(Guid id, Order order);
     }

--- a/src/fiap-order-service/Repositories/OrderRepository.cs
+++ b/src/fiap-order-service/Repositories/OrderRepository.cs
@@ -27,9 +27,9 @@ namespace fiap_order_service.Repositories
             return orders;
         }
 
-        public async Task<Order> GetOrderByIdAsync(Guid id)
+        public async Task<Order?> GetOrderByIdAsync(Guid id)
         {
-            var order = await _context.LoadAsync<Order>(id);
+            var order = await _context.LoadAsync<Order?>(id);
             return order;
         }
 


### PR DESCRIPTION
Modified the `GetOrderByIdAsync` method in both the `IOrderRepository` interface and the `OrderRepository` class to return a nullable `Order` type. This change allows the method to return `null` if an order with the specified ID does not exist, improving flexibility in handling non-existent orders.