### PR TITLE
Update success message in payment processing

### DIFF
--- a/src/fiap-order-service-tests/FunctionTests.cs
+++ b/src/fiap-order-service-tests/FunctionTests.cs
@@ -78,7 +78,7 @@ public class FunctionTests
         var result = await function.ProcessPaymentAsync(paymentRequest);
 
         // Assert
-        Assert.Equal("Pagamento processado com sucesso!", result);
+        Assert.Equal("Pagamento processado com sucesso.", result);
     }
 
     [Fact]
@@ -139,7 +139,7 @@ public class FunctionTests
         await function.FunctionHandler(sqsEvent, contextMock.Object);
 
         // Assert
-        loggerMock.Verify(l => l.LogInformation(It.Is<string>(s => s.Contains("Pagamento processado: Pagamento processado com sucesso!"))), Times.Once);
+        loggerMock.Verify(l => l.LogInformation(It.Is<string>(s => s.Contains("Pagamento processado: Pagamento processado com sucesso."))), Times.Once);
     }
 
     [Fact]

--- a/src/fiap-payment-processor/Function.cs
+++ b/src/fiap-payment-processor/Function.cs
@@ -40,7 +40,7 @@ public class Function
     public async Task<string> ProcessPaymentAsync(PaymentRequest paymentRequest)
     {
         await UpdatePaymentStatusAsync(paymentRequest.OrderId, "PAGO");
-        return "Pagamento processado com sucesso!";
+        return "Pagamento processado com sucesso.";
     }
 
     public async Task<string> UpdatePaymentStatusAsync(string orderId, string status)


### PR DESCRIPTION
Changed the success message in `ProcessPaymentAsync` from "Pagamento processado com sucesso!" to "Pagamento processado com sucesso." Updated corresponding assertions in
`FunctionTests` to reflect this change.