### PR TITLE
Add AWS Lambda support and logging configuration (#21)

### DIFF
--- a/src/fiap-order-service/Program.cs
+++ b/src/fiap-order-service/Program.cs
@@ -24,6 +24,10 @@ builder.Services.Configure<ApiSettings>(builder.Configuration.GetSection("ApiSet
 builder.Services.AddValidatorsFromAssemblyContaining<OrderDtoValidator>();
 builder.Services.AddSingleton<IDynamoDBContext, DynamoDBContext>();
 
+// Add AWS Lambda support. When running the application as an AWS Serverless application, Kestrel is replaced
+// with a Lambda function contained in the Amazon.Lambda.AspNetCoreServer package, which marshals the request into the ASP.NET Core hosting framework.
+builder.Services.AddAWSLambdaHosting(LambdaEventSource.HttpApi);
+
 builder.Services.AddLogging(loggingBuilder =>
 {
     loggingBuilder.AddConsole();

--- a/src/fiap-order-service/fiap-order-service.csproj
+++ b/src/fiap-order-service/fiap-order-service.csproj
@@ -8,6 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="9.1.2" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer.Hosting" Version="1.8.2" />
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.1" />
     <PackageReference Include="AWSSDK.SQS" Version="4.0.0.4" />
     <PackageReference Include="coverlet.msbuild" Version="6.0.4">


### PR DESCRIPTION
Updated `Program.cs` to include AWS Lambda support with the `AddAWSLambdaHosting` method and configured logging for console and debug outputs. Modified `fiap-order-service.csproj` to add package references for `Amazon.Lambda.AspNetCoreServer` and `Amazon.Lambda.AspNetCoreServer.Hosting`.