### PR TITLE
Enhance error handling for catalog service response

### DIFF
--- a/src/fiap-order-service/Infrastructure/HttpClients/CatalogService.cs
+++ b/src/fiap-order-service/Infrastructure/HttpClients/CatalogService.cs
@@ -27,6 +27,10 @@ namespace fiap_order_service.Infrastructure.HttpClients
                     var vehicle = await response.Content.ReadFromJsonAsync<Vehicle>();
                     return vehicle;
                 }
+                else
+                {
+                    _logger.LogWarning("Failed to fetch vehicle from catalog service. Status code: {StatusCode}", response.StatusCode);
+                }
             }
             catch (HttpRequestException ex)
             {


### PR DESCRIPTION
Added logging for unsuccessful responses from the catalog service. An `else` block now captures and logs the status code when the response is not successful, improving the visibility of potential issues.