### PR TITLE
Remove SQS dependency and payment queue functionality

### DIFF
--- a/src/fiap-order-service/Services/IOrderService.cs
+++ b/src/fiap-order-service/Services/IOrderService.cs
@@ -9,6 +9,5 @@ namespace fiap_order_service.Services
         Task<Order?> GetOrderByIdAsync(Guid id);
         Task<Order> CreateOrderAsync(OrderDto orderDto);
         Task<Order?> UpdateStatusOrderAsync(Guid id, string status);
-        Task SendOrderToPaymentQueue(Order order);
     }
 }


### PR DESCRIPTION
Refactored `OrderServiceTests` to eliminate the `ISqsClientService` dependency, removing related mocks and usage in the `OrderService` constructor. The `SendOrderToPaymentQueue` method has been removed from both the `IOrderService` interface and the `OrderService` class, indicating a shift in order processing responsibilities. Corresponding test cases have also been deleted, reflecting the deprecation of this feature.