### PR TITLE
Add PaymentFailed status and update event publishing

### DIFF
--- a/src/fiap-order-service/Constants/OrderStatus.cs
+++ b/src/fiap-order-service/Constants/OrderStatus.cs
@@ -4,6 +4,7 @@
     {
         public const string Created = "CRIADO";
         public const string PendingPayment = "PENDENTE DE PAGAMENTO";
+        public const string PaymentFailed = "PAGAMENTO FALHOU";
         public const string Completed = "PAGO";
         public const string Canceled = "CANCELADO";        
     }

--- a/src/fiap-order-service/Infrastructure/EventBridge/EventBridgePublisher.cs
+++ b/src/fiap-order-service/Infrastructure/EventBridge/EventBridgePublisher.cs
@@ -1,5 +1,6 @@
 ﻿using Amazon.EventBridge;
 using Amazon.EventBridge.Model;
+using fiap_order_service.Constants;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
@@ -21,8 +22,12 @@ namespace fiap_order_service.Infrastructure.EventBridge
             var detail = JsonSerializer.Serialize(new
             {
                 EventType = "CompraCancelada",
-                OrderId = orderId,
-                VehicleId = vehicleId,
+                ReserveVehicleDto = new
+                {
+                    OrderId = orderId,
+                    VehicleId = vehicleId,
+                    Status = OrderStatus.Canceled
+                },                
                 Timestamp = DateTime.UtcNow
             });
 
@@ -56,7 +61,8 @@ namespace fiap_order_service.Infrastructure.EventBridge
                 ReserveVehicleDto = new
                 {
                     OrderId = orderId,
-                    VehicleId = vehicleId
+                    VehicleId = vehicleId,
+                    Status = OrderStatus.Created,
                 },
                 Timestamp = DateTime.UtcNow
             };


### PR DESCRIPTION
- Introduced `PaymentFailed` constant in `OrderStatus`.
- Updated `EventBridgePublisher` to use `OrderStatus` constants.
- Modified `PublicarCompraCanceladaAsync` to include `Status` in `ReserveVehicleDto`.
- Enhanced `CompraRealizada` to consolidate order details with `Status`.