### PR TITLE
Update CatalogService to use hardcoded API URL

### DIFF
--- a/src/fiap-order-service/Infrastructure/HttpClients/CatalogService.cs
+++ b/src/fiap-order-service/Infrastructure/HttpClients/CatalogService.cs
@@ -13,7 +13,7 @@ namespace fiap_order_service.Infrastructure.HttpClients
         public CatalogService(IConfiguration configuration, ILogger<CatalogService> logger)
         {
             _httpClient = new HttpClient();
-            _catalogApiUrl = Environment.GetEnvironmentVariable("CatalogApiUrl") ?? configuration.GetSection("ApiSettings")["CatalogApiUrl"];
+            _catalogApiUrl = "https://qck4zlo8gl.execute-api.us-east-1.amazonaws.com";
             _logger = logger;
         }
 


### PR DESCRIPTION
Changed the initialization of `_catalogApiUrl` in the `CatalogService` constructor to a hardcoded value. This removes the previous functionality of retrieving the URL from environment variables or configuration settings, potentially impacting the service's interaction with the catalog API.